### PR TITLE
feature/null_safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.0
+
+* Migrate to null safety.
+
 #### 2.0.0
 
 * Declare support for Dart 2, drop support for Dart 1.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: quiver_hashcode
-version: 2.0.0
+version: 3.0.0
 authors:
-- Justin Fagnani <justinfagnani@google.com>
-- Yegor Jbanov <yjbanov@google.com>
-- Chris Bracken <cbracken@google.com>
-- Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
-- David Morgan <davidmorgan@google.com>
-- John McDole <codefu@google.com>
-- Matan Lurey <matanl@google.com>
-- Günter Zöchbauer <guenter@gzoechbauer.com>
-- Sean Eagan <seaneagan1@gmail.com>
-- Victor Berchet <victor@suumit.com>
+  - Justin Fagnani <justinfagnani@google.com>
+  - Yegor Jbanov <yjbanov@google.com>
+  - Chris Bracken <cbracken@google.com>
+  - Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
+  - David Morgan <davidmorgan@google.com>
+  - John McDole <codefu@google.com>
+  - Matan Lurey <matanl@google.com>
+  - Günter Zöchbauer <guenter@gzoechbauer.com>
+  - Sean Eagan <seaneagan1@gmail.com>
+  - Victor Berchet <victor@suumit.com>
 description: Compute hashCode correctly for your objects
 homepage: https://github.com/QuiverDart/quiver_hashcode
 
 environment:
-  sdk: '>=2.0.0-dev.61 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  test: '^1.0.0'
+  test: "^1.0.0"


### PR DESCRIPTION
Bumps Dart SDK version as well as package version, making this package publishable to Dart Pub as a null safe package.

Dart migrate suggests no changes to the code.

Tests pass.

Signed CLA.