### PR TITLE
Add migration notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Quiver Hashcode
 [![Build Status](https://travis-ci.org/QuiverDart/quiver_hashcode.svg?branch=master)](https://travis-ci.org/QuiverDart/quiver_hashcode)
 [![Coverage Status](https://img.shields.io/coveralls/QuiverDart/quiver_hashcode.svg)](https://coveralls.io/r/QuiverDart/quiver_hashcode)
 
+## End-of-life
+
+Users of this package should migrate to the `core` library in the main
+[Quiver](https://pub.dev/packages/quiver) package. This code is imported
+as follows:
+
+```dart
+import 'package:quiver/core.dart';
+```
+
+
 ## Documentation
 
 [API Docs](http://www.dartdocs.org/documentation/quiver_hashcode/latest)


### PR DESCRIPTION
Marks this package as end-of-life and suggests that users migrate to the
core libray in the main Quiver package at
https://github.com/google/quiver-dart.